### PR TITLE
Move the homeModule netrc-file definition to always be set

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,10 +84,10 @@
                 "cache.flakehub.com-1:t6986ugxCA+d/ZF9IeMzJkyqi5mDhvFIx7KA/ipulzE="
                 "cache.flakehub.com-2:ntBGiaKSmygJOw2j1hFS7KDlUHQWmZALvSJ9PxMJJYU="
               ];
-              netrc-file = config.determinate.nix.primaryUser.netrcPath;
             })
             {
               extra-substituters = [ "https://cache.flakehub.com" ];
+              netrc-file = config.determinate.nix.primaryUser.netrcPath;
             }
           ];
         };


### PR DESCRIPTION
Turns out this can be set for the user, without making nix complain about trusted settings.

I set my user's nix.conf to be:

```
netrc-file = /Users/grahamchristensen/.local/share/flakehub/netrcccc
```

and then ran `nix config show` and Nix didn't complain about it, and the config was updated. This means Nix is accepting the config for the Nix client, and isn't trying to tell the Nix daemon about our specified netrc-file:

```
% nix config show | grep netrc
warning: unknown experimental feature 'repl-flake'
netrc-file = /Users/grahamchristensen/.local/share/flakehub/netrcccc
```