### PR TITLE
Rename homeManagerModules to homeModules

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For a trusted user, apply a configuration like this (note the `isTrusted` parame
 
         modules = [
           # Load the Determinate module
-          determinate.homeManagerModules.default
+          determinate.homeModules.default
 
           {
             # Required if a trusted user
@@ -147,7 +147,7 @@ Then you can apply a Home Manager configuration along these lines:
 
         modules = [
           # Load the Determinate module
-          determinate.homeManagerModules.default
+          determinate.homeModules.default
 
           {
             # Optional; defaults to `home.username` in Home Manager

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
           };
         });
 
-      homeManagerModules.default = { lib, config, pkgs, ... }: {
+      homeModules.default = { lib, config, pkgs, ... }: {
         imports = [
           inputs.nix.homeManagerModules.default
         ];

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -32,7 +32,7 @@
       pkgs = nixpkgs.legacyPackages.aarch64-darwin;
 
       modules = [
-        determinate.homeManagerModules.default
+        determinate.homeModules.default
         {
           determinate.nix.primaryUser = {
             username = "example";


### PR DESCRIPTION
Eventually we can update Determinate Nix to output `homeModules` instead of `homeManagerModules` but this at least updates how it's exposed to users here.