### PR TITLE
Reinstate Darwin package outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,30 @@ jobs:
           nix develop --command \
             lychee README.md
 
+  verify-outputs:
+    strategy:
+      matrix:
+        runners:
+          - { system: aarch64-darwin, runner: macos-latest-xlarge }
+          - { system: x86_64-darwin, runner: macos-latest-xlarge }
+          - { system: aarch64-linux, runner: UbuntuLatest32Cores128GArm }
+          - { system: x86_64-linux, runner: UbuntuLatest32Cores128GArm  }
+
+    runs-on: ${{ matrix.runners.runner }}
+
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+      - uses: DeterminateSystems/flakehub-cache-action@main
+      - run: nix build .#packages."$SYSTEM".default
+        env:
+          SYSTEM: ${{ matrix.runners.system }}
+
   test-modules:
     strategy:
       matrix:
@@ -58,7 +82,7 @@ jobs:
           git diff --exit-code
 
   success:
-    needs: [checks, test-modules]
+    needs: [checks, verify-outputs, test-modules]
     runs-on: ubuntu-latest
     steps:
       - run: true

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,17 @@
 {
   "nodes": {
+    "determinate-nixd-aarch64-darwin": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-IH1qnluG839hv2K2uOQ3W5tluoTFYwFrqwCC8qN+jQY=",
+        "type": "file",
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.5.0/macOS"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.5.0/macOS"
+      }
+    },
     "determinate-nixd-aarch64-linux": {
       "flake": false,
       "locked": {
@@ -175,7 +187,11 @@
     },
     "root": {
       "inputs": {
+        "determinate-nixd-aarch64-darwin": "determinate-nixd-aarch64-darwin",
         "determinate-nixd-aarch64-linux": "determinate-nixd-aarch64-linux",
+        "determinate-nixd-x86_64-darwin": [
+          "determinate-nixd-aarch64-darwin"
+        ],
         "determinate-nixd-x86_64-linux": "determinate-nixd-x86_64-linux",
         "nix": "nix",
         "nixpkgs": "nixpkgs_2"

--- a/flake.nix
+++ b/flake.nix
@@ -13,14 +13,18 @@
       url = "https://install.determinate.systems/determinate-nixd/tag/v3.5.0/x86_64-linux";
       flake = false;
     };
+    determinate-nixd-aarch64-darwin = {
+      url = "https://install.determinate.systems/determinate-nixd/tag/v3.5.0/macOS";
+      flake = false;
+    };
+    determinate-nixd-x86_64-darwin.follows = "determinate-nixd-aarch64-darwin";
   };
 
   outputs = { self, nixpkgs, ... } @ inputs:
     let
-      linuxSystems = [ "x86_64-linux" "aarch64-linux" ];
-      allSystems = linuxSystems ++ [ "aarch64-darwin" "x86_64-darwin" ];
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
 
-      forSystems = systems: f: nixpkgs.lib.genAttrs systems (system: f {
+      forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f {
         inherit system;
         pkgs = import nixpkgs {
           inherit system;
@@ -29,12 +33,9 @@
           };
         };
       });
-
-      forLinuxSystems = forSystems linuxSystems;
-      forAllSystems = forSystems allSystems;
     in
     {
-      packages = forLinuxSystems ({ system, pkgs, ... }: {
+      packages = forEachSupportedSystem ({ system, pkgs, ... }: {
         default = pkgs.runCommand "determinate-nixd" { } ''
           mkdir -p $out/bin
           cp ${inputs."determinate-nixd-${system}"} $out/bin/determinate-nixd
@@ -43,7 +44,7 @@
         '';
       });
 
-      devShells = forAllSystems ({ system, pkgs, ... }:
+      devShells = forEachSupportedSystem ({ system, pkgs, ... }:
         {
           default = pkgs.mkShell {
             name = "determinate-dev";


### PR DESCRIPTION
Apparently these are required by Determinate Nix Installer as part of the release process.