### PR TITLE
Put NixOS-generated nix.conf instead at nix.custom.conf

### DIFF
--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -73,6 +73,10 @@ in
       inputs.self.packages.${pkgs.stdenv.system}.default
     ];
 
+    # NOTE(cole-h): Move the generated nix.conf to /etc/nix/nix.custom.conf, which is included from
+    # the Determinate Nixd-managed /etc/nix/nix.conf.
+    environment.etc."nix/nix.conf".target = "nix/nix.custom.conf";
+
     systemd.services.nix-daemon.serviceConfig = {
       ExecStart = [
         ""


### PR DESCRIPTION
This makes it such that when Determinate Nixd replaces /etc/nix/nix.conf with its required config, the user-specified options that would have been set in that overwritten symlink will instead be set in the nix.custom.conf file (which is loaded if it exists).