### PR TITLE
Add `determinate.enable` option

### DIFF
--- a/modules/nix-darwin.nix
+++ b/modules/nix-darwin.nix
@@ -1,5 +1,7 @@
-{ lib, options, ... }:
+{ lib, options, config, ... }:
 let
+  cfg = config.determinate;
+
   postMigrationInstructions = ''
     You have successfully migrated your Determinate installation.
     Please remove `determinate.darwinModules.default` from your
@@ -12,7 +14,11 @@ let
   '';
 in
 {
-  config =
+  options.determinate = {
+    enable = lib.mkEnableOption "Determinate Nix" // { default = true; };
+  };
+
+  config = lib.mkIf cfg.enable (
     # Check if nix-darwin is new enough for the `nix.enable` option.
     if options.nix.enable.visible or true then
       {
@@ -85,5 +91,6 @@ in
             '';
           }
         ];
-      };
+      }
+  );
 }

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -3,6 +3,8 @@ inputs:
 { lib, pkgs, config, ... }:
 
 let
+  cfg = config.determinate;
+
   # Stronger than mkDefault (1000), weaker than mkForce (50) and the "default override priority"
   # (100).
   mkPreferable = lib.mkOverride 750;
@@ -13,7 +15,7 @@ let
   # The settings configured in this module must be generally settable by users both trusted and
   # untrusted by the Nix daemon. Settings that require being a trusted user belong in the
   # `restrictedSettingsModule` below.
-  commonNixSettingsModule = { config, pkgs, lib, ... }: {
+  commonNixSettingsModule = { config, pkgs, lib, ... }: lib.mkIf cfg.enable {
     nix.package = inputs.nix.packages."${pkgs.stdenv.system}".default;
 
     nix.registry.nixpkgs = {
@@ -38,7 +40,11 @@ in
     commonNixSettingsModule
   ];
 
-  config = {
+  options.determinate = {
+    enable = lib.mkEnableOption "Determinate Nix" // { default = true; };
+  };
+
+  config = lib.mkIf cfg.enable {
     environment.systemPackages = [
       inputs.self.packages.${pkgs.stdenv.system}.default
     ];


### PR DESCRIPTION
This allows for importing the module without always applying its effects -- mainly for cases like creating shared abstractions between systems that aren't all using Determinate

A use case I personally have for this is enabling Determinate on most of my systems by default (by importing a shared module), but explicitly disabling it for some. Currently this is only possible by either importing this module in each system repeatedly, or through `disabledModules` in systems I wish to exclude. I don't think either of these are very nice solutions

The new option is set to `true` by default, so this should be perfectly backwards compatible