### PR TITLE
Provide default value for custom settings

### DIFF
--- a/modules/nix-darwin/default.nix
+++ b/modules/nix-darwin/default.nix
@@ -40,6 +40,7 @@ in
       # Support "free-form" options
       freeformType = semanticConfType;
     };
+    default = {};
   };
 
   config = lib.mkIf (config.determinate-nix.customSettings != { }) {

--- a/modules/nix-darwin/default.nix
+++ b/modules/nix-darwin/default.nix
@@ -40,7 +40,7 @@ in
       # Support "free-form" options
       freeformType = semanticConfType;
     };
-    default = {};
+    default = { };
   };
 
   config = lib.mkIf (config.determinate-nix.customSettings != { }) {

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -37,9 +37,27 @@
           system = "aarch64-darwin";
 
           modules = [
+            determinate.darwinModules.default
             {
               nix.enable = false;
               system.stateVersion = 5;
+            }
+          ];
+        }).system;
+
+      checks.aarch64-darwin.nix-darwin-custom-config =
+        (nix-darwin.lib.darwinSystem {
+          system = "aarch64-darwin";
+
+          modules = [
+            determinate.darwinModules.default
+            {
+              nix.enable = false;
+              system.stateVersion = 5;
+              determinate-nix.customSettings = {
+                extra-experimental-features = [ "build-time-fetch-tree" ];
+                flake-registry = "/etc/nix/flake-registry.json";
+              };
             }
           ];
         }).system;


### PR DESCRIPTION
Without this default, evaluating a nix-darwin config that uses this module fails if `determinate-nix.customSettings` is unspecified. As we can reasonably expect many people to not use this, we should set a default of `{}`, which the module handles by not writing any `nix.custom.conf`.