### PR TITLE
Fix broken link to installation instructions for NixOS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can get started with Determinate in one of two ways:
 | :------------------------------ | :--------------------------------------------------------------------------- |
 | **Linux** but not using [NixOS] | [Determinate Nix Installer](#installing-using-the-determinate-nix-installer) |
 | **macOS**                       | [Determinate Nix Installer](#installing-using-the-determinate-nix-installer) |
-| **Linux** and using [NixOS]     | The [NixOS module](#nixos) provided by this flake                            |
+| **Linux** and using [NixOS]     | The [NixOS module](#installing-using-our-nix-flake) provided by this flake                            |
 
 ## Installing using the Determinate Nix Installer
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to fix the NixOS entry’s link, directing readers to the correct “Installing using our Nix flake” section.
  * Improves navigation and clarity for NixOS users seeking installation/setup guidance.
  * No functional or API changes; this update only enhances documentation accuracy and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->