### PR TITLE
feat(flake): nix.inputs.nixpkgs.follows = "nixpkgs"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,10 @@
   description = "Determinate";
 
   inputs = {
-    nix.url = "https://flakehub.com/f/DeterminateSystems/nix-src/*";
+    nix = {
+      url = "https://flakehub.com/f/DeterminateSystems/nix-src/*";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     nixpkgs.url = "https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/0.1";
 
     determinate-nixd-aarch64-linux = {


### PR DESCRIPTION
CLOSES: #138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured Nix flake inputs: the nix input is now a structured entry that follows nixpkgs, aligning input relationships and update propagation.

* **Chores**
  * Updated input wiring to reflect the new structure.
  * No changes to user-facing behavior or commands; existing workflows continue to function as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->