### PR TITLE
Remove external link check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Check Nix formatting
         run: git ls-files '*.nix' | nix develop --command xargs nixfmt --check
 
-      - name: Check external links in README
-        run: nix develop --command check-readme-links
-
   verify-outputs:
     strategy:
       matrix:

--- a/flake.nix
+++ b/flake.nix
@@ -65,12 +65,7 @@
             name = "determinate-dev";
 
             packages = with pkgs; [
-              lychee
-              nixfmt-rfc-style
-
-              (writeScriptBin "check-readme-links" ''
-                lychee README.md
-              '')
+              self.formatter.${system}
             ];
           };
         }


### PR DESCRIPTION
This repo sits in the hot path of our release process and external link checking is often brittle. Worth the pain for important web properties but seems like overkill for just a README that's likely to change very infrequently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed external link validation from automated checks.
  * Updated development environment configuration to streamline tooling setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->