### PR TITLE
Drop x86_64-darwin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
       matrix:
         runners:
           - { system: aarch64-darwin, runner: macos-latest-xlarge }
-          - { system: x86_64-darwin, runner: macos-latest-xlarge }
           - { system: aarch64-linux, runner: UbuntuLatest32Cores128GArm }
           - { system: x86_64-linux, runner: UbuntuLatest32Cores128G }
 

--- a/flake.lock
+++ b/flake.lock
@@ -181,9 +181,6 @@
       "inputs": {
         "determinate-nixd-aarch64-darwin": "determinate-nixd-aarch64-darwin",
         "determinate-nixd-aarch64-linux": "determinate-nixd-aarch64-linux",
-        "determinate-nixd-x86_64-darwin": [
-          "determinate-nixd-aarch64-darwin"
-        ],
         "determinate-nixd-x86_64-linux": "determinate-nixd-x86_64-linux",
         "nix": "nix",
         "nixpkgs": "nixpkgs_2"

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,6 @@
       url = "https://install.determinate.systems/determinate-nixd/tag/v3.12.2/macOS";
       flake = false;
     };
-    determinate-nixd-x86_64-darwin.follows = "determinate-nixd-aarch64-darwin";
   };
 
   outputs =
@@ -27,7 +26,6 @@
         "x86_64-linux"
         "aarch64-linux"
         "aarch64-darwin"
-        "x86_64-darwin"
       ];
 
       forEachSupportedSystem =


### PR DESCRIPTION
Implements https://github.com/DeterminateSystems/nix-src/issues/224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Discontinued support for macOS x86_64 systems. Supported platforms are now aarch64-darwin, aarch64-linux, and x86_64-linux.
  * CI no longer runs verification on macOS x86_64, and build/configuration platform listings have been updated to reflect this change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->