### PR TITLE
Use determinate-specific input names

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ To add the `determinate` flake as a [flake input][flake-inputs]:
 }
 ```
 
-> We recommend not using a [`follows`][follows] directive for [Nixpkgs] (`inputs.nixpkgs.follows = "nixpkgs"`) in conjunction with the Determinate flake, as it leads to cache misses for artifacts otherwise available from [FlakeHub Cache][cache].
-
 You can quickly set up Determinate using the `nixosModules.default` module output from this flake.
 Here's an example NixOS configuration for the current stable NixOS:
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,28 @@
 {
   "nodes": {
+    "determinate-nix": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "git-hooks-nix": "git-hooks-nix",
+        "nixpkgs": [
+          "determinate-nixpkgs"
+        ],
+        "nixpkgs-23-11": "nixpkgs-23-11",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1768960381,
+        "narHash": "sha256-32oMe1y+kwvIJNiJsIvozTuSmDxcwST06i+0ak+L4AU=",
+        "rev": "45ce621408cb8c9a724193d5fe858eb839662db8",
+        "revCount": 24453,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.15.2/019bde75-b4ee-74b2-a812-28dc2ee83d58/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/DeterminateSystems/nix-src/%2A"
+      }
+    },
     "determinate-nixd-aarch64-darwin": {
       "flake": false,
       "locked": {
@@ -36,6 +59,20 @@
         "url": "https://install.determinate.systems/determinate-nixd/tag/v3.15.2/x86_64-linux"
       }
     },
+    "determinate-nixpkgs": {
+      "locked": {
+        "lastModified": 1769433173,
+        "narHash": "sha256-Gf1dFYgD344WZ3q0LPlRoWaNdNQq8kSBDLEWulRQSEs=",
+        "rev": "13b0f9e6ac78abbbb736c635d87845c4f4bee51b",
+        "revCount": 934966,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.934966%2Brev-13b0f9e6ac78abbbb736c635d87845c4f4bee51b/019bfdf9-4ec8-7a28-a5b9-d7a7d3cfef53/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/0.1"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -55,7 +92,7 @@
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
-          "nix",
+          "determinate-nix",
           "nixpkgs"
         ]
       },
@@ -76,10 +113,10 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "gitignore": [
-          "nix"
+          "determinate-nix"
         ],
         "nixpkgs": [
-          "nix",
+          "determinate-nix",
           "nixpkgs"
         ]
       },
@@ -94,41 +131,6 @@
       "original": {
         "type": "tarball",
         "url": "https://flakehub.com/f/cachix/git-hooks.nix/0.1.941"
-      }
-    },
-    "nix": {
-      "inputs": {
-        "flake-parts": "flake-parts",
-        "git-hooks-nix": "git-hooks-nix",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-23-11": "nixpkgs-23-11",
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1768960381,
-        "narHash": "sha256-32oMe1y+kwvIJNiJsIvozTuSmDxcwST06i+0ak+L4AU=",
-        "rev": "45ce621408cb8c9a724193d5fe858eb839662db8",
-        "revCount": 24453,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.15.2/019bde75-b4ee-74b2-a812-28dc2ee83d58/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/DeterminateSystems/nix-src/%2A"
-      }
-    },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1761597516,
-        "narHash": "sha256-wxX7u6D2rpkJLWkZ2E932SIvDJW8+ON/0Yy8+a5vsDU=",
-        "rev": "daf6dc47aa4b44791372d6139ab7b25269184d55",
-        "revCount": 811874,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.811874%2Brev-daf6dc47aa4b44791372d6139ab7b25269184d55/019a3494-3498-707e-9086-1fb81badc7fe/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2505"
       }
     },
     "nixpkgs-23-11": {
@@ -163,27 +165,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1768783163,
-        "narHash": "sha256-tLj4KcRDLakrlpvboTJDKsrp6z2XLwyQ4Zmo+w8KsY4=",
-        "rev": "bde09022887110deb780067364a0818e89258968",
-        "revCount": 930106,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.930106%2Brev-bde09022887110deb780067364a0818e89258968/019bd9ed-5f0b-7074-afb0-8bb5e13a7598/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/0.1"
-      }
-    },
     "root": {
       "inputs": {
+        "determinate-nix": "determinate-nix",
         "determinate-nixd-aarch64-darwin": "determinate-nixd-aarch64-darwin",
         "determinate-nixd-aarch64-linux": "determinate-nixd-aarch64-linux",
         "determinate-nixd-x86_64-linux": "determinate-nixd-x86_64-linux",
-        "nix": "nix",
-        "nixpkgs": "nixpkgs_2"
+        "determinate-nixpkgs": "determinate-nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,11 @@
   description = "Determinate";
 
   inputs = {
-    nix.url = "https://flakehub.com/f/DeterminateSystems/nix-src/*";
-    nixpkgs.url = "https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/0.1";
+    determinate-nix = {
+      url = "https://flakehub.com/f/DeterminateSystems/nix-src/*";
+      inputs.nixpkgs.follows = "determinate-nixpkgs";
+    };
+    determinate-nixpkgs.url = "https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/0.1";
 
     determinate-nixd-aarch64-linux = {
       url = "https://install.determinate.systems/determinate-nixd/tag/v3.15.2/aarch64-linux";
@@ -20,7 +23,7 @@
   };
 
   outputs =
-    { self, nixpkgs, ... }@inputs:
+    { self, determinate-nixpkgs, ... }@inputs:
     let
       supportedSystems = [
         "x86_64-linux"
@@ -30,11 +33,11 @@
 
       forEachSupportedSystem =
         f:
-        nixpkgs.lib.genAttrs supportedSystems (
+        determinate-nixpkgs.lib.genAttrs supportedSystems (
           system:
           f {
             inherit system;
-            pkgs = import nixpkgs {
+            pkgs = import determinate-nixpkgs {
               inherit system;
               config = {
                 allowUnfree = true;


### PR DESCRIPTION
I watch my flake.lock pretty closely and don't like duplicate inputs. This renames generic inputs to something specific to Determinate -- since Determinate doesn't want users overriding `nixpkgs`.

Here's a snippet from my `flake.nix` which removes duplicate inputs:

```
    # TODO: update to upstream input when PR is merged
    determinate-nixpkgs.url = "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.811874%2Brev-daf6dc47aa4b44791372d6139ab7b25269184d55/019a3494-3498-707e-9086-1fb81badc7fe/source.tar.gz"; 

    determinate-nix = {
      url = "github:heywoodlh/nix-src/fix-input-conflict";
      inputs.determinate-nixpkgs.follows = "determinate-nixpkgs";
      inputs.flake-parts.follows = "flake-parts";
      inputs.git-hooks-nix.follows = "pre-commit-hooks";
    };
    determinate = {
      url = "github:heywoodlh/determinate/fix-input-conflict";
      inputs.determinate-nixpkgs.follows = "determinate-nixpkgs";
      inputs.determinate-nix.follows = "determinate-nix";
    };
```

Should probably not be merged until the same PR is approved and merged in nix-src.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed outdated guidance regarding follows directives.

* **Chores**
  * Updated core project dependencies for improved build consistency and reproducibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->