### PR TITLE
feat(flake): substituters

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,15 @@
     };
   };
 
+  nixConfig = {
+    extra-substituters = [
+      "https://install.determinate.systems"
+    ];
+    extra-trusted-public-keys = [
+      "cache.flakehub.com-3:hJuILl5sVK4iKm86JzgdXW12Y2Hwd5G07qKtHTOcDCM="
+    ];
+  };
+
   outputs =
     { self, nixpkgs, ... }@inputs:
     let


### PR DESCRIPTION
Feature [native substituters suggestion / hint](https://wiki.nixos.org/wiki/Binary_Cache#Binary_cache_hint_in_Flakes) to `flake.nix`

This will also be shown in `flake.nix` importing this flake

## References

- https://docs.determinate.systems/guides/advanced-installation
- https://wiki.nixos.org/wiki/Flakes#Nix_configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system configuration with additional package substitution sources and trusted signing keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->