### PR TITLE
Add `determinateNixd.telemetry.sentry.endpoint`

### DIFF
--- a/modules/nix-darwin/default.nix
+++ b/modules/nix-darwin/default.nix
@@ -273,6 +273,13 @@ in
                 The garbage collection strategy used by Determinate Nixd. `automatic` means that Determinate Nixd automatically collects garbage in the background while `disabled` means no garbage collection.
               '';
             };
+            telemetry.sentry.endpoint = lib.mkOption {
+              type = types.nullOr types.str;
+              default = "unset";
+              description = ''
+                The Sentry endpoint for uploading crash reports. Set to `null` to disable crash reporting.
+              '';
+            };
           };
         };
         default = { };
@@ -780,7 +787,12 @@ in
                   );
               in
               lib.mkIf (explicitlySetAttrs != { }) {
-                text = builtins.toJSON explicitlySetAttrs;
+                text = builtins.toJSON (
+                  explicitlySetAttrs
+                  // lib.optionalAttrs (dnixd.telemetry.sentry.endpoint != "unset") {
+                    telemetry.sentry.endpoint = dnixd.telemetry.sentry.endpoint;
+                  }
+                );
               };
 
             # List of machines for distributed Nix builds in the format

--- a/modules/nix-darwin/default.nix
+++ b/modules/nix-darwin/default.nix
@@ -785,14 +785,14 @@ in
                       ]
                     ]
                   );
-              in
-              lib.mkIf (explicitlySetAttrs != { }) {
-                text = builtins.toJSON (
+                configAttrs =
                   explicitlySetAttrs
                   // lib.optionalAttrs (dnixd.telemetry.sentry.endpoint != "unset") {
                     telemetry.sentry.endpoint = dnixd.telemetry.sentry.endpoint;
-                  }
-                );
+                  };
+              in
+              lib.mkIf (configAttrs != { }) {
+                text = builtins.toJSON configAttrs;
               };
 
             # List of machines for distributed Nix builds in the format


### PR DESCRIPTION
Add the missing `telemetry` Determinate Nixd
[option](https://docs.determinate.systems/determinate-nix/#determinate-nixd-configuration).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable Sentry endpoint for crash-reporting telemetry. Default is "unset"; set a custom endpoint to enable reporting or set to null to disable. When configured, the endpoint is included in the generated Determinate Nixd configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/determinate/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->