### PR TITLE
modules: add edgeCacheSubstituters options

### DIFF
--- a/modules/nix-darwin/default.nix
+++ b/modules/nix-darwin/default.nix
@@ -280,6 +280,14 @@ in
                 The Sentry endpoint for uploading crash reports. Set to `null` to disable crash reporting.
               '';
             };
+            edgeCacheSubstituters = lib.mkOption {
+              type = types.nullOr (types.listOf types.str);
+              default = null;
+              example = [ "https://cache.example.com/" ];
+              description = ''
+                A list of substituter URLs that Determinate Nixd should treat as edge caches. These URLs are written as the top-level `edgeCacheSubstituters` key in {file}`/etc/determinate/config.json`.
+              '';
+            };
           };
         };
         default = { };
@@ -783,6 +791,7 @@ in
                         "garbageCollector"
                         "strategy"
                       ]
+                      [ "edgeCacheSubstituters" ]
                     ]
                   );
                 configAttrs =

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -56,6 +56,15 @@ in
     enable = lib.mkEnableOption "Determinate Nix" // {
       default = true;
     };
+
+    edgeCacheSubstituters = lib.mkOption {
+      type = lib.types.nullOr (lib.types.listOf lib.types.str);
+      default = null;
+      example = [ "https://cache.example.com/" ];
+      description = ''
+        A list of substituter URLs that Determinate Nixd should treat as edge caches. These URLs are written as the top-level `edgeCacheSubstituters` key in {file}`/etc/determinate/config.json`.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -66,6 +75,12 @@ in
     # NOTE(cole-h): Move the generated nix.conf to /etc/nix/nix.custom.conf, which is included from
     # the Determinate Nixd-managed /etc/nix/nix.conf.
     environment.etc."nix/nix.conf".target = "nix/nix.custom.conf";
+
+    environment.etc."determinate/config.json" = lib.mkIf (cfg.edgeCacheSubstituters != null) {
+      text = builtins.toJSON {
+        edgeCacheSubstituters = cfg.edgeCacheSubstituters;
+      };
+    };
 
     systemd = {
       services.nix-daemon.serviceConfig = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options to specify edge cache substituter URLs for Determinate Nixd in NixOS and nix-darwin environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/determinate/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->